### PR TITLE
Tweak how we do polyfilling to be less aggressive

### DIFF
--- a/app/templates/gulpfile.js/tasks/test-node.js
+++ b/app/templates/gulpfile.js/tasks/test-node.js
@@ -6,7 +6,7 @@ var argv = require('yargs').argv;
 var reporters = require('jasmine-reporters');
 var jasmineConf = require('../../tests/support/jasmine.json');
 
-require('babel-core/register')({stage: 1});
+require('babel-core/register')({ stage: 1 });
 
 var reportsDir = './reports';
 

--- a/app/templates/tests/support/jasmine.json
+++ b/app/templates/tests/support/jasmine.json
@@ -4,6 +4,8 @@
     "tests/unit/**/*_spec.js"
   ],
   "helpers": [
-    "tests/helpers/**/*_helpers.js"
+    "node_modules/babelify/polyfill.js",
+    "tests/support/helpers/**/*_helpers.js",
+    "tests/support/mocks/**/*_mock.js"
   ]
 }


### PR DESCRIPTION
Previously we were including the polyfill in the final transpiled lib. This caused
issues when requiring it as libraries that are requireing us may also want to
include the polyfill. Unfortuately, the polyfill will cause errors if it's included
more than once.

Longer term we need a better solution for this. In the shorter term the convention
is that the "top level" library should include the polyfilly when building. This
lib now only includes the polyfill when running it's own tests.
